### PR TITLE
Integrate email tool pages into site: favicon, descriptions, titles

### DIFF
--- a/email-tools/ers-tool-feedback.html
+++ b/email-tools/ers-tool-feedback.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Email Readability Score — Holistic Email Marketing — Jonathan Pay</title>
+  <meta name="description" content="Score your email copy's readability with Flesch-Kincaid, Gunning Fog, and SMOG — with per-word syllable counting and actionable suggestions. No sign-up needed.">
+  <title>Email Readability Score — Jonathan Pay</title>
+  <link rel="icon" href="/favicon.ico">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="tool-page.css">
   <style>

--- a/email-tools/f2b-tool.html
+++ b/email-tools/f2b-tool.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Feature-to-Benefit Converter — Holistic Email Marketing — Jonathan Pay</title>
+  <meta name="description" content="Turn product features into customer benefits. Pick your industry, enter a feature, and get a benefit statement from 384 templates across 8 verticals. No sign-up needed.">
+  <title>Feature-to-Benefit Converter — Jonathan Pay</title>
+  <link rel="icon" href="/favicon.ico">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="tool-page.css">
   <style>

--- a/email-tools/sscc.html
+++ b/email-tools/sscc.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Statistical Significance Calculator — Holistic Email Marketing — Jonathan Pay</title>
+  <meta name="description" content="Check whether your email A/B test result is statistically significant before you act on it. Enter sample sizes and conversion rates — no sign-up needed.">
+  <title>Statistical Significance Calculator — Jonathan Pay</title>
+  <link rel="icon" href="/favicon.ico">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="tool-page.css">
   <style>

--- a/email-tools/tone-tool.html
+++ b/email-tools/tone-tool.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Email Tone Analyzer — Holistic Email Marketing — Jonathan Pay</title>
+  <meta name="description" content="Detect the tone of your email copy across five dimensions — Friendly, Persuasive, Professional, Urgent, and Empathetic — with phrase suggestions for shifting tone. No sign-up needed.">
+  <title>Email Tone Analyzer — Jonathan Pay</title>
+  <link rel="icon" href="/favicon.ico">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="tool-page.css">
   <style>

--- a/email-tools/wewe-tool.html
+++ b/email-tools/wewe-tool.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>We-We Calculator — Holistic Email Marketing — Jonathan Pay</title>
+  <meta name="description" content="Check if your email copy talks about you or to your reader. Count brand-focused vs. customer-focused pronouns instantly — no sign-up needed.">
+  <title>We-We Calculator — Jonathan Pay</title>
+  <link rel="icon" href="/favicon.ico">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="tool-page.css">
   <style>


### PR DESCRIPTION
Each individual tool page was missing a favicon link, meta description, and had "Holistic Email Marketing" in the title rather than just the site name. Now consistent with email-tools/index.html.

https://claude.ai/code/session_01CnfEre98bXouksxuJwgkZR