### PR TITLE
Replace single email tools card with individual per-tool project cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,13 +449,34 @@
       <section>
         <h2>Projects <span>/</span></h2>
         <div class="project-grid">
-          <a href="/email-tools/" class="project-card">
-            <div class="project-card-label">Free Tools</div>
-            <h3>Email Optimisation Tools</h3>
-            <p>
-              Five browser-based tools for email marketers — readability scoring,
-              tone analysis, A/B significance testing, and more. No sign-up needed.
-            </p>
+          <a href="/email-tools/wewe-tool.html" class="project-card">
+            <div class="project-card-label">Foundation</div>
+            <h3>We-We Calculator</h3>
+            <p>Is your copy talking about you, or to your reader? Paste your email and see the brand vs. customer split instantly.</p>
+          </a>
+
+          <a href="/email-tools/ers-tool-feedback.html" class="project-card">
+            <div class="project-card-label">Foundation</div>
+            <h3>Email Readability Score</h3>
+            <p>How hard is your email to read? Score your copy against Flesch-Kincaid, Gunning Fog, and SMOG with actionable suggestions.</p>
+          </a>
+
+          <a href="/email-tools/f2b-tool.html" class="project-card">
+            <div class="project-card-label">Intermediate</div>
+            <h3>Feature-to-Benefit Converter</h3>
+            <p>Enter a feature, pick your industry, and get a customer-benefit statement from 384 templates across 8 verticals.</p>
+          </a>
+
+          <a href="/email-tools/sscc.html" class="project-card">
+            <div class="project-card-label">Intermediate</div>
+            <h3>A/B Significance Calculator</h3>
+            <p>Before you call a winner, check the maths. Enter sample sizes and conversion rates to get a statistically valid result.</p>
+          </a>
+
+          <a href="/email-tools/tone-tool.html" class="project-card">
+            <div class="project-card-label">Intermediate</div>
+            <h3>Email Tone Analyzer</h3>
+            <p>Detect how Friendly, Persuasive, Professional, Urgent, or Empathetic your copy reads — with phrases to shift the balance.</p>
           </a>
         </div>
       </section>


### PR DESCRIPTION
## Summary

- Replaces the single "Email Optimisation Tools" project card with five individual cards, one per tool
- Each card has a punchy tease description and links directly to that tool
- Labels show the difficulty level (Foundation / Intermediate) matching the email tools index

## Test plan

- [ ] Visit the homepage and confirm the Projects section shows 5 individual tool cards
- [ ] Click each card and confirm it lands on the correct tool page
- [ ] Check the layout at narrow widths (the grid already uses `auto-fill` so should wrap cleanly)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnfEre98bXouksxuJwgkZR)_