### PR TITLE
Add custom Pages deployment workflow to bypass Jekyll

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Replaces the auto-detected Jekyll pipeline with a direct static-file upload via actions/upload-pages-artifact + actions/deploy-pages. Eliminates the jekyll-build-pages download failures seen in CI.

https://claude.ai/code/session_019jduQq1LwhmgbNK4TWERSS